### PR TITLE
Allow hypens in aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1 - 16/02/20
+### Changed
+- allow hyphens in aliases
+
 ## 1.1.0 - 19/06/19
 ### Changed
 - `goto --list` prints sorted tab separated table

--- a/goto.fish
+++ b/goto.fish
@@ -129,7 +129,7 @@ function __goto_cleanup
 end
 
 function ___goto_version
-    echo "1.1.0"
+    echo "1.1.1"
 end
 
 function __goto_find_aliases

--- a/goto.fish
+++ b/goto.fish
@@ -44,9 +44,9 @@ function __goto_register
     set acronym $argv[2]
     set directory $argv[3]
 
-    if not test (string match -r '^[\d\w_]+$' $acronym)
+    if not test (string match -r '^[\d\w_-]+$' $acronym)
         echo "Invalid alias: '$acronym'. Alises can contain only letters, \
-digits and underscores."
+digits, hyphens and underscores."
         return 1
     end
 
@@ -133,7 +133,7 @@ function ___goto_version
 end
 
 function __goto_find_aliases
-    __goto_list | string match -r '.+?\b'
+    __goto_list | string match -r '.+?\s'
 end
 
 function goto -d 'quickly navigate to aliased directories'


### PR DESCRIPTION
Thanks for this port! 🙌

`goto` for bash [allows aliases with hypens](https://github.com/iridakos/goto/blob/master/goto.sh#L175) and not just underscores. Unless there is an issue it would be nice if this would support it too!